### PR TITLE
Fix mongodb adapter versioning conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "fs-extra": "^11.1.0",
     "gray-matter": "^4.0.3",
     "ioredis": "^5.2.5",
-    "mongodb": "^5.1.0",
+    "mongodb": "^4.1.1",
     "next": "13.0.4",
     "next-auth": "^4.20.1",
     "react": "18.2.0",


### PR DESCRIPTION
Hotfix for conflict between `@next-auth/mongodb-adapter` and root dependency